### PR TITLE
jupyter timeout

### DIFF
--- a/autogen/coding/jupyter/jupyter_client.py
+++ b/autogen/coding/jupyter/jupyter_client.py
@@ -149,6 +149,9 @@ class JupyterKernelClient:
         self._websocket.settimeout(timeout_seconds)
         try:
             data = self._websocket.recv()
+            if not data:
+                # getting 0 bytes is usually a silent EOF
+                return None
             if isinstance(data, bytes):
                 data = data.decode("utf-8")
             return cast(Dict[str, Any], json.loads(data))

--- a/autogen/coding/jupyter/jupyter_code_executor.py
+++ b/autogen/coding/jupyter/jupyter_code_executor.py
@@ -89,7 +89,12 @@ class JupyterCodeExecutor(CodeExecutor):
         Returns:
             IPythonCodeResult: The result of the code execution.
         """
-        self._jupyter_kernel_client.wait_for_ready()
+        connected = self._jupyter_kernel_client.wait_for_ready()
+        if not connected:
+            # fresh connection but use the same kernel id
+            self._jupyter_client = JupyterClient(self._connection_info)
+            self._jupyter_kernel_client = self._jupyter_client.get_kernel_client(self._kernel_id)
+
         outputs = []
         output_files = []
         for code_block in code_blocks:


### PR DESCRIPTION
This pull request includes improvements to error handling and connection management in the Jupyter client and code executor.

Enhancements to error handling:

* [`autogen/coding/jupyter/jupyter_client.py`](diffhunk://#diff-0c6efea7bd2fc28f245357ce22c261f6236ff2f6187cbcf819e59451857ec4ddR152-R154): Added a check for empty data in `_receive_message` method to handle silent EOF scenarios.

Improvements to connection management:

* [`autogen/coding/jupyter/jupyter_code_executor.py`](diffhunk://#diff-d975e149504627a452e23a3e8ada1d420c61ee156b42ad84f16271699b07f020L92-R97): Modified `execute_code_blocks` method to handle reconnection logic if the initial connection attempt fails.<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->