### PR TITLE
Ignore a BrokenPipeError and let the parent handle the None

### DIFF
--- a/autogen/coding/jupyter/jupyter_client.py
+++ b/autogen/coding/jupyter/jupyter_client.py
@@ -157,6 +157,9 @@ class JupyterKernelClient:
             return cast(Dict[str, Any], json.loads(data))
         except websocket.WebSocketTimeoutException:
             return None
+        except BrokenPipeError:
+            # this is a non-silent error
+            return None
 
     def wait_for_ready(self, timeout_seconds: Optional[float] = None) -> bool:
         message_id = self._send_message(content={}, channel="shell", message_type="kernel_info_request")


### PR DESCRIPTION
This pull request includes a small but important change to the `autogen/coding/jupyter/jupyter_client.py` file. The change adds error handling for a `BrokenPipeError` in the `_receive_message` method, ensuring that the error can be recovered from and returns `None`.

Error handling improvements:

* [`autogen/coding/jupyter/jupyter_client.py`](diffhunk://#diff-0c6efea7bd2fc28f245357ce22c261f6236ff2f6187cbcf819e59451857ec4ddR160-R162): Added a catch for `BrokenPipeError` in the `_receive_message` method to handle the error and return `None`.<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
